### PR TITLE
(Cosmetic) Made case type more consistent

### DIFF
--- a/Luai/init.lua
+++ b/Luai/init.lua
@@ -1,7 +1,7 @@
 return function (Source : string)
 	local Tokens, ErrorMessage = require(script.Lexer).new(Source):generate_tokens()
 	if Tokens then
-		require(script.Parser).new(tokens):parse()
+		require(script.Parser).new(Tokens):parse()
 	else
 		warn(ErrorMessage)
 	end

--- a/Luai/init.lua
+++ b/Luai/init.lua
@@ -1,8 +1,8 @@
-return function (source : string)
-	local tokens, error_ = require(script.Lexer).new(source):generate_tokens()
-	if tokens then
+return function (Source : string)
+	local Tokens, Error = require(script.Lexer).new(Source):generate_tokens()
+	if Tokens then
 		require(script.Parser).new(tokens):parse()
 	else
-		warn(error_)
+		warn(Error)
 	end
 end

--- a/Luai/init.lua
+++ b/Luai/init.lua
@@ -1,8 +1,8 @@
 return function (Source : string)
-	local Tokens, Error = require(script.Lexer).new(Source):generate_tokens()
+	local Tokens, ErrorMessage = require(script.Lexer).new(Source):generate_tokens()
 	if Tokens then
 		require(script.Parser).new(tokens):parse()
 	else
-		warn(Error)
+		warn(ErrorMessage)
 	end
 end


### PR DESCRIPTION
The naming of the modules are in PascalCase, but the inside of the scripts are written in camelCase. Luau's official styleguide also states Luau should be written in PascalCase for consistency. Also, the underscore can hurt readability, someone would expect an underscore to be in-between two words, but you've used it here to prevent Roblox replacing the error message with the global "error" function.